### PR TITLE
Revert lsi mod

### DIFF
--- a/Software/Projects/B-L072Z-LRWAN1/Applications/LoRa/End_Node/Core/src/mlm32l0xx_hal_msp.c
+++ b/Software/Projects/B-L072Z-LRWAN1/Applications/LoRa/End_Node/Core/src/mlm32l0xx_hal_msp.c
@@ -116,18 +116,18 @@ void HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc)
   RCC_PeriphCLKInitTypeDef  PeriphClkInitStruct;
 
   /*##-1- Configue the RTC clock soucre ######################################*/
-  /* -a- Enable LS1 Oscillator */
-  RCC_OscInitStruct.OscillatorType =  RCC_OSCILLATORTYPE_LSI;
+  /* -a- Enable LSE Oscillator */
+  RCC_OscInitStruct.OscillatorType =  RCC_OSCILLATORTYPE_LSE;
   RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.LSIState = RCC_LSI_ON;
+  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
   if(HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
   {
     Error_Handler();
   }
 
-  /* -b- Select LSI as RTC clock source */
+  /* -b- Select LSE as RTC clock source */
   PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
   if(HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
   { 
     Error_Handler();


### PR DESCRIPTION
Using the LSI oscillator instead of the LSE makes lots of problems with timings. Because the RTC used to use a 32768hz crystal LSE. Switching to the 37Khz internal oscillator opens a bag of worms