### PR TITLE
memset gps info to all zeros at start of gps search

### DIFF
--- a/Software/Drivers/BSP/Components/ublox/ublox.c
+++ b/Software/Drivers/BSP/Components/ublox/ublox.c
@@ -244,6 +244,9 @@ gps_status_t get_location_fix(uint32_t timeout){
 	init_for_fix();
 	
 	HAL_IWDG_Refresh(&hiwdg);
+	
+	/* Set all the GPS info values to zeros */
+	memset(&gps_info, 0, sizeof(gps_info_t));
 
 	/* poll UBX-NAV-PVT until the module has fix */	
 	uint32_t startTime = HAL_GetTick();

--- a/Software/Drivers/BSP/Components/ublox/ublox.h
+++ b/Software/Drivers/BSP/Components/ublox/ublox.h
@@ -36,8 +36,8 @@ extern "C"
 
 typedef enum
 {
-	GPS_SUCCESS = 0,
-	GPS_FAILURE
+	GPS_FAILURE = 0,
+	GPS_SUCCESS
 } gps_status_t;
 
 


### PR DESCRIPTION
Necessary to redefine GPS_FAILURE = 0 because when memsetting all to zero, I want to ensure the default is failure.