### PR TITLE
Undo gps speedups

### DIFF
--- a/Software/Drivers/BSP/Components/ublox/ublox.c
+++ b/Software/Drivers/BSP/Components/ublox/ublox.c
@@ -148,7 +148,6 @@ gps_status_t Backup_GPS()
  */
 gps_status_t setup_GPS()
 {
-	HAL_Delay(GPS_WAKEUP_TIMEOUT);
 
 	// wake up gps in case it is in Lower Power mode
 	HAL_GPIO_WritePin(GPS_INT_GPIO_Port, GPS_INT_Pin, GPIO_PIN_SET); // pull GPS extint0 pin high to wake gps

--- a/Software/Drivers/BSP/Components/ublox/ublox.c
+++ b/Software/Drivers/BSP/Components/ublox/ublox.c
@@ -140,17 +140,21 @@ gps_status_t Backup_GPS()
 	{
 		PRINTF("put_in_power_save_mode carried out successfully!\n");
 	}
+	//HAL_GPIO_WritePin(GPS_INT_GPIO_Port, GPS_INT_Pin, GPIO_PIN_RESET);    // force GPS backup mode by pulling GPS extint pin low
 	return GPS_SUCCESS;
 }
 
 /* 
  * sets up gps by putting in airbourne mode, setting to use GPS satellites only, turning off NMEA
+ * Needs TO BE REFACTORED TO TIME OUT OR EXIT IF NO MESSAGED IS ReCEIVED BACK!
  */
 gps_status_t setup_GPS()
 {
 
 	// wake up gps in case it is in Lower Power mode
 	HAL_GPIO_WritePin(GPS_INT_GPIO_Port, GPS_INT_Pin, GPIO_PIN_SET); // pull GPS extint0 pin high to wake gps
+	factoryReset();
+	HAL_Delay(GPS_WAKEUP_TIMEOUT); // Wait for things to be setup
 
 	/* Set the I2C port to output UBX only (turn off NMEA noise) */
 	if (setI2COutput(COM_TYPE_UBX, defaultMaxWait) == false) //Set the I2C port to output UBX only (turn off NMEA noise)
@@ -400,6 +404,12 @@ static gps_status_t init_for_fix()
 
 static gps_status_t reinit_gps()
 {
+	HAL_IWDG_Refresh(&hiwdg);
+
+	// configure gps module again
+	factoryReset();
+	HAL_Delay(GPS_WAKEUP_TIMEOUT); // wait for GPS module to be ready
+
 	HAL_IWDG_Refresh(&hiwdg);
 
 	if (setI2COutput(COM_TYPE_UBX, defaultMaxWait) == false) //Set the I2C port to output UBX only (turn off NMEA noise)

--- a/Software/Projects/B-L072Z-LRWAN1/Applications/LoRa/End_Node/LoRaWAN/App/src/i2c_middleware.c
+++ b/Software/Projects/B-L072Z-LRWAN1/Applications/LoRa/End_Node/LoRaWAN/App/src/i2c_middleware.c
@@ -21,6 +21,7 @@
 #include <i2c_middleware.h>
 #include "hw_i2c.h"
 #include "hw.h" // for PRINTF
+#include "main.h"
 
 
 /* ==================================================================== */
@@ -123,8 +124,34 @@ I2C_MIDDLEWARE_STATUS_t I2C_receive_mem(I2C_HandleTypeDef* hi2c, uint16_t DevAdd
 		}
 	
 	return I2C_FAIL;
+}	
+
+void I2C_pins_GPIO_INPUT_init(){
+	
+	GPIO_InitTypeDef GPIO_InitStruct = {0};
+
+	/* Configure SDA,SCL pin as input */
+	GPIO_InitStruct.Pin = GPIO_PIN_9|GPIO_PIN_8;
+	GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+	GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+	GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+	HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+	
 }
 
+void I2C_pins_GPIO_OUTPUT_init(){
+
+	GPIO_InitTypeDef GPIO_InitStruct = {0};
+
+  /*Configure GPIO pin : PB9 | PB8 */
+  GPIO_InitStruct.Pin = GPIO_PIN_9|GPIO_PIN_8;
+  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+}	
+	
 /* rapidly toggle the i2c lines to get it unstuck
  * Workaround to solve this mysterious problem where the sda line
  * appears to get stuck low.
@@ -133,9 +160,72 @@ I2C_MIDDLEWARE_STATUS_t reinit_i2c(I2C_HandleTypeDef* hi2c)
 {
 	HAL_IWDG_Refresh(&hiwdg);
 	
-	PRINTF("I2C ERROR!");	
+	//////////////////////////////////////////////////////////////
+	/* COMPLETELY USELESS FROM HERE */
+	
+	/* disable power to GPS */
+	HAL_GPIO_WritePin(GPS_EN_GPIO_Port, GPS_EN_PIN, GPIO_PIN_SET); 
+	HAL_Delay(100);
+  
+  /* De-initialize the I2C comunication bus */
+  HAL_I2C_MspDeInit(hi2c);
+  
+	/* Make I2C bus pins GPIO */
+	I2C_pins_GPIO_OUTPUT_init();
+	
+	/* set i2c pins low to ensure it cannot power up the core of the GPS */
+	HAL_GPIO_WritePin(GPS_EN_GPIO_Port, GPIO_PIN_9|GPIO_PIN_8, GPIO_PIN_RESET); 
+	HAL_Delay(1000);
+	
+	/* Enable power to GPS */
+	HAL_GPIO_WritePin(GPS_EN_GPIO_Port, GPS_EN_PIN, GPIO_PIN_RESET); 
+	HAL_Delay(1000);
+	
+	/* send 9 clock pulses to the GPS ref: https://www.microchip.com/forums/FindPost/175578 */
+	for (uint8_t i = 0; i < 9; i++)
+	{
+		HAL_GPIO_WritePin(GPS_EN_GPIO_Port, GPIO_PIN_8, GPIO_PIN_RESET); 
+		HAL_Delay(1);
+		HAL_GPIO_WritePin(GPS_EN_GPIO_Port, GPIO_PIN_8, GPIO_PIN_SET); 
+		HAL_Delay(1);
 
-	/* Re-Initiaize the I2C comunication bus */	
+	}
+	
+
+	
+	/* COMPLETELY USELESS TO HERE */
+	/////////////////////////////////////////////////////////////////
+	
+	// check if sda is stuck low. if so, call error handler
+	
+	I2C_pins_GPIO_INPUT_init();
+	
+	/**I2C1 GPIO Configuration    
+	PB9     ------> I2C1_SDA
+	PB8     ------> I2C1_SCL 
+	*/
+	
+	volatile GPIO_PinState pinstate_scl =  HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_8);
+	volatile GPIO_PinState pinstate_sda =  HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_9);
+	
+	if ((pinstate_scl == GPIO_PIN_RESET) || (pinstate_sda == GPIO_PIN_RESET))
+	{
+			// only the error handler fixes it. carry out a software reset
+			PRINTF("SCL OR SDA STUCK LOW. calling Error_Handler().\n");
+	}
+	else
+	{
+			PRINTF("I2C not stuck low, carry on.\n");	
+	}
+
+	
+	/* Re-Initiaize the I2C comunication bus */
+	HAL_I2C_MspInit(hi2c);
+	
+	PRINTF("I2C not stuck low, carry on.\n");	
+	
+	PRINTF("Deinit i2c\n");	
+
 	HAL_StatusTypeDef status = HAL_I2C_DeInit(hi2c);
 	
 	


### PR DESCRIPTION
The recovery does not recover the second max m8q tracker. Even power cycling does not work. The prescribed method the only bullet proof method. Don't change.